### PR TITLE
Allow omission of params

### DIFF
--- a/lib/fast_inserter/fast_inserter_base.rb
+++ b/lib/fast_inserter/fast_inserter_base.rb
@@ -47,8 +47,8 @@ module FastInserter
 
     def initialize(params)
       @table_name = params[:table]
-      @static_columns = params[:static_columns]
-      @additional_columns = params[:additional_columns]
+      @static_columns = params[:static_columns] || {}
+      @additional_columns = params[:additional_columns] || {}
       @variable_columns = Array(params[:variable_columns] || params[:variable_column])
       @options = params[:options] || {}
 


### PR DESCRIPTION
Sometimes, there's no need for `static_columns` or `additional_columns`